### PR TITLE
Fix bulleted list in layout.md documentation

### DIFF
--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1,6 +1,7 @@
 ## Memory Layout
 
 The memory layout for the tree structure used by this library has the following properties:
+
 - It is based on a contiguous memory slice.
 - It is built in-place, as such children are placed directly after their parent.
 - Attributes are immediately stored after a node.


### PR DESCRIPTION
Greetings, a random redditor in from https://www.reddit.com/r/cpp/comments/1ko2ivj/xml_library_for_huge_mostly_immutable_files/. I noticed the top bullets on the doc page (https://lazy-eggplant.github.io/vs.xml/latest/docs/layout/) weren't showing up, while the lower bullets were.

(huh, I'm not sure why the last line is showing as changed 😶)